### PR TITLE
Allow more options for k8s service accounts

### DIFF
--- a/k8s/basic/cluster/cluster.tf
+++ b/k8s/basic/cluster/cluster.tf
@@ -28,11 +28,12 @@ resource "kubernetes_secret" "docker-config" {
 }
 
 resource "kubernetes_service_account" "service_account" {
-  for_each = toset(compact(distinct([for name, service in var.services: service.service_account])))
+  for_each = {for name, service in var.services: service.service_account.name => service.service_account}
 
   metadata {
     namespace = var.app_namespace
-    name = each.value
+    name = each.value.name
+    annotations = each.value.annotations
   }
 }
 
@@ -70,7 +71,7 @@ resource "kubernetes_deployment" "deployment" {
         namespace = var.app_namespace
       }
       spec {
-        service_account_name = each.value.service_account != null ? kubernetes_service_account.service_account[each.value.service_account].metadata[0].name : "default"
+        service_account_name = each.value.service_account.name != null ? kubernetes_service_account.service_account[each.value.service_account.name].metadata[0].name : "default"
 
         dynamic "image_pull_secrets" {
           for_each = var.dcr_credentials != "" ? { default = var.dcr_credentials } : {}

--- a/k8s/basic/cluster/variables.tf
+++ b/k8s/basic/cluster/variables.tf
@@ -21,7 +21,10 @@ variable "services" {
       deployment_labels = optional(map(string))
       service_labels = optional(map(string))
       pod_labels = optional(map(string))
-      service_account = optional(string)
+      service_account = optional(object({
+        name = optional(string)
+        annotations = optional(map(string))
+      }))
       replicas = number
       image = string
       ports = list(number)

--- a/k8s/basic/variables.tf
+++ b/k8s/basic/variables.tf
@@ -27,7 +27,10 @@ variable "services" {
       deployment_labels = optional(map(string))
       service_labels = optional(map(string))
       pod_labels = optional(map(string))
-      service_account = optional(string)
+      service_account = optional(object({
+        name = optional(string)
+        annotations = optional(map(string))
+      }))
       replicas = number
       image = string
       ports = list(number)


### PR DESCRIPTION
### Breaking Changes

`service_account` attribute of a service is now an object and not a string.
The attributes was used previously to set the name of a service account. After this change `name` is an attribute of an object assigned to `service_account`.

Before:
```terraform
service_account = "foo"
```

After:
```terraform
service_account = {
  name = "foo"
}
```

### Whats New

It is now possible to add `annotations` metadata to k8s service accounts:

```terraform
service_account = {
  name = "foo"
  annotations = {
    "eks.amazonaws.com/role-arn" = aws_iam_role.foo_role.arn
  }
}
```