### PR TITLE
Example of Kubernetes cluster on DigitalOcean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .terraform
 .terraform.lock.hcl
+terraform.tfstate*

--- a/do/k8s/main.tf
+++ b/do/k8s/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     digitalocean = {
       source = "digitalocean/digitalocean"
-      version = "~> 2.17.0"
+      version = "~> 2.29.0"
     }
   }
 }

--- a/do/k8s/main.tf
+++ b/do/k8s/main.tf
@@ -30,7 +30,7 @@ resource "digitalocean_kubernetes_cluster" "k8s_cluster" {
 }
 
 resource "digitalocean_container_registry" "container_registry" {
-  name = var.project
+  name = var.registry
   subscription_tier_slug = var.container_registry_plan
 }
 

--- a/do/k8s/variables.tf
+++ b/do/k8s/variables.tf
@@ -6,6 +6,10 @@ variable "region" {
   type = string
 }
 
+variable "registry" {
+  type = string
+}
+
 variable "k8s" {
   type = object({
     node_size = string

--- a/examples/do-cluster/README.md
+++ b/examples/do-cluster/README.md
@@ -2,13 +2,17 @@
 
 1. Generate personal access tokens for DigitalOcean API and save it to `DIGITALOCEAN_TOKEN` environment variable.
 
-2. Initialize the Terraform configuration:
+2. Create DO space for storing terraform state.
+
+3. Generate Spaces access key and secret key.
+
+4. Initialize the Terraform configuration with your Spaces access key and secret key:
 
 ```
-terraform init
+terraform init -backend-config "access_key=SPACES_ACCESS_KEY" -backend-config "secret_key=SPACES_SECRET_KEY"
 ```
 
-3. Due to limitations of kubernetes-alpha provider we have to apply configuration in multiple steps:
+5. Due to limitations of kubernetes-alpha provider we have to apply configuration in multiple steps:
 
 ```
 terraform apply -target module.eks

--- a/examples/do-cluster/README.md
+++ b/examples/do-cluster/README.md
@@ -1,0 +1,18 @@
+# DigitalOcean cluster
+
+1. Generate personal access tokens for DigitalOcean API and save it to `DIGITALOCEAN_TOKEN` environment variable.
+
+2. Initialize the Terraform configuration:
+
+```
+terraform init
+```
+
+3. Due to limitations of kubernetes-alpha provider we have to apply configuration in multiple steps:
+
+```
+terraform apply -target module.eks
+terraform apply -target module.database
+terraform apply -target module.kubernetes.module.dependencies
+terraform apply
+```

--- a/examples/do-cluster/app.tf
+++ b/examples/do-cluster/app.tf
@@ -1,0 +1,79 @@
+module "digitalocean" {
+  source = "git@github.com:datarockets/infrastructure.git//do/k8s?ref=example-digital-ocean"
+
+  project = "first-project"
+  registry = "first-project-test"
+  region = "tor1"
+
+  database = {
+    name = "example"
+    username = "example"
+  }
+}
+
+provider "kubernetes" {
+  host = module.digitalocean.k8s_host
+  token = module.digitalocean.k8s_token
+  cluster_ca_certificate = module.digitalocean.k8s_ca_certificate
+}
+
+provider "kubernetes-alpha" {
+  host = module.digitalocean.k8s_host
+  token = module.digitalocean.k8s_token
+  cluster_ca_certificate = module.digitalocean.k8s_ca_certificate
+}
+
+provider "helm" {
+  kubernetes {
+    host = module.digitalocean.k8s_host
+    token = module.digitalocean.k8s_token
+    cluster_ca_certificate = module.digitalocean.k8s_ca_certificate
+  }
+}
+
+module "kubernetes" {
+  source = "git@github.com:datarockets/infrastructure.git//k8s/basic?ref=example-digital-ocean"
+  depends_on = [
+    module.digitalocean
+  ]
+
+  app = "example"
+  email = "example@datarockets.com"
+  dcr_credentials = module.digitalocean.dcr_credentials_k8s
+  services = {
+    app = {
+      replicas = 1
+      image = "nginx:latest"
+      ports = [80]
+      env_from_secrets = ["example"]
+    }
+  }
+  web_services = ["app"]
+  # ingresses = {
+  #   "example.datarockets.com" = {
+  #     annotations = {
+  #     }
+  #     rules = [
+  #       {
+  #         host = "example.datarockets.com"
+  #         paths = [
+  #           {
+  #             path = "/"
+  #             service = "app"
+  #             port = 80
+  #           }
+  #         ]
+  #       }
+  #     ]
+  #   }
+  # }
+  secrets = {
+    example = {
+      DB_HOST = module.digitalocean.db_host
+      DB_PORT = module.digitalocean.db_port
+      DB_USER = module.digitalocean.db_user
+      DB_PASSWORD = module.digitalocean.db_password
+      DB_DATABASE = module.digitalocean.db_database
+    }
+  }
+}

--- a/examples/do-cluster/app.tf
+++ b/examples/do-cluster/app.tf
@@ -1,3 +1,15 @@
+terraform {
+  backend "s3" {
+    key      = "terraform.tfstate"
+    bucket   = "first-project-test"
+    region   = "tor1"
+    endpoint = "fra1.digitaloceanspaces.com"
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+  }
+}
+
 module "digitalocean" {
   source = "git@github.com:datarockets/infrastructure.git//do/k8s?ref=example-digital-ocean"
 

--- a/k8s/basic/cluster/cluster.tf
+++ b/k8s/basic/cluster/cluster.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 resource "kubernetes_secret" "secret" {
   for_each = var.secrets
 

--- a/k8s/basic/ingress/ingress.tf
+++ b/k8s/basic/ingress/ingress.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 resource "kubernetes_ingress" "ingress" {
   metadata {
     name = var.name

--- a/k8s/basic/main.tf
+++ b/k8s/basic/main.tf
@@ -10,7 +10,6 @@ terraform {
       version = "~> 2.4.1"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 module "dependencies" {


### PR DESCRIPTION
Changes:
- Added config for DigitalOcean with database, registry and Kubernetes cluster
- Removed `experiments = [module_variable_optional_attrs]`, because it's no longer available in new terraform version
- Upgraded DO provider version
- Moved terraform.tfstate to S3 to hide sensitive information
- Added registry name as variable, because it should be unique

To do:
- [ ] Setup domain name and uncomment ingress
