### PR TITLE
Remove TF deprecated experiment

### DIFF
--- a/k8s/basic/cluster/cluster.tf
+++ b/k8s/basic/cluster/cluster.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 resource "kubernetes_secret" "secret" {
   for_each = var.secrets
 

--- a/k8s/basic/ingress/ingress.tf
+++ b/k8s/basic/ingress/ingress.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 resource "kubernetes_ingress" "ingress" {
   metadata {
     name      = var.name

--- a/k8s/basic/main.tf
+++ b/k8s/basic/main.tf
@@ -10,7 +10,6 @@ terraform {
       version = "~> 2.4.1"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 module "dependencies" {


### PR DESCRIPTION
`module_variable_optional_attrs` isn't experiment anymore and enabled by default in Terraform > 1.3.