### PR TITLE
Remove unused variables from `k8s/basic`

### DIFF
--- a/examples/aws-eks-cluster/app.tf
+++ b/examples/aws-eks-cluster/app.tf
@@ -109,9 +109,6 @@ module "kubernetes" {
 
   depends_on = [module.eks]
 
-  create_app_namespace = false
-  app_namespace        = module.eks.app_namespace
-
   app   = var.app
   email = var.email
 

--- a/k8s/basic/variables.tf
+++ b/k8s/basic/variables.tf
@@ -1,13 +1,3 @@
-variable "create_app_namespace" {
-  type    = bool
-  default = true
-}
-
-variable "app_namespace" {
-  type    = string
-  default = "default"
-}
-
 variable "app" {
   type = string
 }


### PR DESCRIPTION
It removes unused variables `create_app_namespace` and `app_namespace`.