### PR TITLE
Upgrade `nginx-ingress` package

### DIFF
--- a/k8s/basic/dependencies/dependencies.tf
+++ b/k8s/basic/dependencies/dependencies.tf
@@ -29,7 +29,7 @@ resource "helm_release" "cert-manager" {
 resource "helm_release" "nginx-ingress" {
   name       = "nginx-ingress"
   chart      = "nginx-ingress"
-  version    = "0.12.0"
+  version    = "1.1.3"
   repository = "https://helm.nginx.com/stable"
   namespace  = "kube-system"
 


### PR DESCRIPTION
The official documentation describes a different way of installing the chart via Helm ([source](https://docs.nginx.com/nginx-ingress-controller/installation/installing-nic/installation-with-helm/)) but I checked and they still support `https://helm.nginx.com/stable` so decided to keep it.

I don't know how it might affect the existing infrastructures during an upgrade and couldn't test it.