### PR TITLE
Upgrade helm charts and AWS modules

### DIFF
--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -35,7 +35,7 @@ variable "legacy_iam_role_name" {
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
-  version = "3.11.3"
+  version = "5.14.0"
 
   name = "${var.app}-${var.environment}"
   cidr = var.vpc_cidr
@@ -49,7 +49,7 @@ module "vpc" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.2.0"
+  version = "20.26.1"
 
   cluster_name = "${var.app}-${var.environment}"
   cluster_version = var.cluster_version

--- a/aws/postgresql/postgresql.tf
+++ b/aws/postgresql/postgresql.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.62"
     }
     random = {
       source = "hashicorp/random"
@@ -69,7 +69,7 @@ resource "aws_security_group" "database" {
 
 module "rds" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "3.5.0"
+  version = "6.10.0"
 
   identifier = "${var.app}-${var.environment}"
 
@@ -84,9 +84,9 @@ module "rds" {
   backup_retention_period = 15
   maintenance_window = "Mon:00:00-Mon:03:00"
 
-  name = "main"
+  db_name = "main"
   username = "root"
-  create_random_password = true
+  manage_master_user_password = true
   port = 5432
 
   subnet_ids = [for subnet in aws_subnet.database: subnet.id]

--- a/k8s/basic/dependencies/dependencies.tf
+++ b/k8s/basic/dependencies/dependencies.tf
@@ -16,12 +16,16 @@ resource "kubernetes_namespace" "cert-manager" {
 resource "helm_release" "cert-manager" {
   name       = "cert-manager"
   chart      = "cert-manager"
-  version    = "1.6.1"
+  version    = "1.16.1"
   repository = "https://charts.jetstack.io"
   namespace  = kubernetes_namespace.cert-manager.id
 
   set {
-    name  = "installCRDs"
+    name  = "crds.enabled"
+    value = "true"
+  }
+  set {
+    name = "crds.keep"
     value = "true"
   }
 }
@@ -29,7 +33,7 @@ resource "helm_release" "cert-manager" {
 resource "helm_release" "nginx-ingress" {
   name       = "nginx-ingress"
   chart      = "nginx-ingress"
-  version    = "0.12.0"
+  version    = "1.4.0"
   repository = "https://helm.nginx.com/stable"
   namespace  = "kube-system"
 


### PR DESCRIPTION
Upgrade
`cert-manager` to `1.16.1`
`nginx-ingress` to `1.4.0`

AWS modules
`terraform-aws-modules/vpc/aws` to `5.14.0`
`terraform-aws-modules/eks/aws` to `20.26.1`
`terraform-aws-modules/rds/aws` to `6.10.0`