### PR TITLE
Integrate Trivy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1
+        with:
+          version: v0.65.0
+          cache: true
+      - run: bin/scan

--- a/aws/eks/auth/cicd/cicd-auth.tf
+++ b/aws/eks/auth/cicd/cicd-auth.tf
@@ -27,6 +27,9 @@ variable "ecr_repository_arns" {
   type = list(string)
 }
 
+# Ignored rule: One or more policies are attached directly to a user
+# is ignored since it shouldn't be critical in cicd
+#trivy:ignore:AVD-AWS-0143
 resource "aws_iam_user" "cicd" {
   name = "cicd"
   path = "/automation/${var.app}/${var.environment}/"

--- a/aws/eks/eks.tf
+++ b/aws/eks/eks.tf
@@ -86,6 +86,9 @@ module "eks" {
 
 # We need it to make cert-manager to work since it makes an http request to
 # public self during the self-check while issuing a new certificate.
+# Ignored rule: Security group rule allows unrestricted egress to any IP address
+# is ignored for cert-manager since it makes an request to public server
+#trivy:ignore:AVD-AWS-0104
 resource "aws_security_group_rule" "eks_node_egress_to_http" {
   security_group_id = module.eks.node_security_group_id
   description = "Egress to http (port 80)"

--- a/aws/terraform_backend/main.tf
+++ b/aws/terraform_backend/main.tf
@@ -1,3 +1,8 @@
+# Ignored rules:
+#   Bucket does not have encryption enabled
+#   Bucket has logging disabled
+#   Bucket does not encrypt data with a customer managed key
+#trivy:ignore:AVD-AWS-0089 trivy:ignore:AVD-AWS-0132 trivy:ignore:AVD-AWS-0088
 resource "aws_s3_bucket" "state" {
   bucket = var.s3_bucket
 }
@@ -10,6 +15,10 @@ resource "aws_s3_bucket_versioning" "state" {
   }
 }
 
+# Ignored rules:
+#   Point-in-time recovery is not enabled
+#   Table encryption does not use a customer-managed KMS key
+#trivy:ignore:AVD-AWS-0024 trivy:ignore:AVD-AWS-0025
 resource "aws_dynamodb_table" "state" {
   name         = var.dynamodb_table
   billing_mode = "PAY_PER_REQUEST"
@@ -19,4 +28,13 @@ resource "aws_dynamodb_table" "state" {
     name = "LockID"
     type = "S"
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/bin/scan
+++ b/bin/scan
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+cd "$(dirname "$0")/.."
+
+trivy config ./ --tf-exclude-downloaded-modules --skip-dirs examples --skip-dirs templates $@

--- a/do/k8s/main.tf
+++ b/do/k8s/main.tf
@@ -16,11 +16,12 @@ resource "digitalocean_vpc" "vpc" {
 
 data "digitalocean_kubernetes_versions" "k8s_versions" {}
 resource "digitalocean_kubernetes_cluster" "k8s_cluster" {
-  name         = var.project
-  region       = var.region
-  auto_upgrade = true
-  version      = data.digitalocean_kubernetes_versions.k8s_versions.latest_version
-  vpc_uuid     = digitalocean_vpc.vpc.id
+  name          = var.project
+  region        = var.region
+  auto_upgrade  = true
+  surge_upgrade = true
+  version       = data.digitalocean_kubernetes_versions.k8s_versions.latest_version
+  vpc_uuid      = digitalocean_vpc.vpc.id
 
   node_pool {
     name       = "default-pool"


### PR DESCRIPTION
PR adds integrating trivy and relates to this [issue](https://github.com/datarockets/infrastructure/issues/22)

Trivy is used, because of now tfsec is part of the trivy