### PR TITLE
Add support for Kubernetes cluster autoscaling DO

### DIFF
--- a/do/k8s/main.tf
+++ b/do/k8s/main.tf
@@ -3,7 +3,7 @@
 terraform {
   required_providers {
     digitalocean = {
-      source = "digitalocean/digitalocean"
+      source  = "digitalocean/digitalocean"
       version = "~> 2.29.0"
     }
   }
@@ -26,11 +26,14 @@ resource "digitalocean_kubernetes_cluster" "k8s_cluster" {
     name       = "default-pool"
     size       = var.k8s.node_size
     node_count = var.k8s.node_count
+    auto_scale = var.k8s.min_nodes != null && var.k8s.max_nodes != null
+    min_nodes  = var.k8s.min_nodes
+    max_nodes  = var.k8s.max_nodes
   }
 }
 
 resource "digitalocean_container_registry" "container_registry" {
-  name = var.registry
+  name                   = var.registry
   subscription_tier_slug = var.container_registry_plan
 }
 

--- a/do/k8s/variables.tf
+++ b/do/k8s/variables.tf
@@ -13,11 +13,21 @@ variable "registry" {
 variable "k8s" {
   type = object({
     node_size  = string
-    node_count = string
+    node_count = optional(number)
+    min_nodes  = optional(number)
+    max_nodes  = optional(number)
   })
   default = {
     node_size  = "s-2vcpu-2gb"
     node_count = 1
+  }
+
+  validation {
+    condition = (
+      (var.k8s.node_count != null && (var.k8s.min_nodes == null && var.k8s.max_nodes == null)) ||
+      (var.k8s.node_count == null && (var.k8s.min_nodes != null && var.k8s.max_nodes != null))
+    )
+    error_message = "You need to indicate either node count or min_nodes with max_nodes for enabling autoscaling, not both options"
   }
 }
 


### PR DESCRIPTION
PR adds support for Digital Ocean Kubernetes cluster autoscaling

It relates to this [issue](https://github.com/datarockets/infrastructure/issues/16).

Note: Adding autoscaling for aws will be introduced in the separate PR